### PR TITLE
specify site headers

### DIFF
--- a/site_monitor.py
+++ b/site_monitor.py
@@ -7,11 +7,13 @@ import time
 import difflib
 
 url = raw_input("Enter website to monitor: ")
-
+#set the site headers to be used by the requests library, this tells requests to use the same user agent every time it refreshes
+#just in case requests changes user agents for some reason, not sure but this will/should prevent that
+headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
 t = int(raw_input("Wait time: "))
 
 while True:
-	r1  = requests.get(url)
+	r1  = requests.get(url, headers=headers)
 	data1 = r1.text
 	soup1 = BeautifulSoup(data1, "html.parser")
 


### PR DESCRIPTION
see comments in the code, site headers specify a user agent, could in theory help with the program detecting false changes due to the target site thinking the bot is on a different web browser